### PR TITLE
fix scene matching except missing walls

### DIFF
--- a/bddl/activity_definitions/assembling_furniture/problem0.bddl
+++ b/bddl/activity_definitions/assembling_furniture/problem0.bddl
@@ -6,18 +6,18 @@
         floor.n.01_1 - floor.n.01
         agent.n.01_1 - agent.n.01
     )
-    
-    (:init 
-        (not 
+
+    (:init
+        (not
             (assembled desk.n.01_1)
-        ) 
-        (inroom floor.n.01_1 living_room) 
-        (inroom desk.n.01_1 living_room) 
+        )
+        (inroom floor.n.01_1 living_room)
+        (ontop desk.n.01_1 floor.n.01_1)
         (ontop agent.n.01_1 floor.n.01_1)
     )
-    
-    (:goal 
-        (and 
+
+    (:goal
+        (and
             (assembled ?desk.n.01_1)
         )
     )

--- a/bddl/activity_definitions/clean_walls/problem0.bddl
+++ b/bddl/activity_definitions/clean_walls/problem0.bddl
@@ -19,9 +19,9 @@
         (covered wall.n.01_1 stain.n.01_1)
         (ontop swab.n.02_1 floor.n.01_1)
         (insource sink.n.01_1 water.n.06_1)
-        (inroom wall.n.01_1 utility_room) 
-        (inroom sink.n.01_1 utility_room) 
-        (inroom floor.n.01_1 utility_room)
+        (inroom wall.n.01_1 kitchen)
+        (inroom sink.n.01_1 kitchen)
+        (inroom floor.n.01_1 kitchen)
         (ontop agent.n.01_1 floor.n.01_1) 
     )
     

--- a/bddl/activity_definitions/cleaning_barbecue_grill/problem0.bddl
+++ b/bddl/activity_definitions/cleaning_barbecue_grill/problem0.bddl
@@ -5,7 +5,7 @@
         stain.n.01_1 - stain.n.01
         dust.n.01_1 - dust.n.01
      	grill.n.02_1 - grill.n.02
-    	floor.n.01_1 - floor.n.01
+    	floor.n.01_1 floor.n.01_2 - floor.n.01
     	rag.n.01_1 - rag.n.01
     	bucket.n.01_1 - bucket.n.01
         countertop.n.01_1 - countertop.n.01
@@ -13,15 +13,16 @@
         agent.n.01_1 - agent.n.01
     )
     
-    (:init 
-        (inroom grill.n.02_1 garden)
+    (:init
+        (inroom floor.n.01_2 garden)
+        (ontop grill.n.02_1 floor.n.01_2)
         (covered grill.n.02_1 stain.n.01_1) 
         (covered grill.n.02_1 dust.n.01_1) 
         (ontop bucket.n.01_1 countertop.n.01_1) 
         (ontop rag.n.01_1 countertop.n.01_1) 
         (inroom floor.n.01_1 garage) 
-        (inroom countertop.n.01_1 utility_room) 
-        (inroom sink.n.01_1 utility_room)
+        (inroom countertop.n.01_1 kitchen)
+        (inroom sink.n.01_1 kitchen)
         (ontop agent.n.01_1 floor.n.01_1)
     )
     

--- a/bddl/activity_definitions/cleaning_the_pool/problem0.bddl
+++ b/bddl/activity_definitions/cleaning_the_pool/problem0.bddl
@@ -6,7 +6,6 @@
      	pool.n.01_1 - pool.n.01
     	floor.n.01_1 - floor.n.01
     	scrub_brush.n.01_1 - scrub_brush.n.01
-    	shelf.n.01_1 - shelf.n.01
     	detergent.n.02_1 - detergent.n.02
     	detergent__bottle.n.01_1 - detergent__bottle.n.01
         sink.n.01_1 - sink.n.01
@@ -19,19 +18,16 @@
         (ontop scrub_brush.n.01_1 floor.n.01_1)
         (filled detergent__bottle.n.01_1 detergent.n.02_1)
         (ontop detergent__bottle.n.01_1 floor.n.01_1)
-        (inroom shelf.n.01_1 garage) 
-        (inroom floor.n.01_1 garage) 
-        (inroom sink.n.01_1 utility_room)
+        (inroom floor.n.01_1 garage)
+        (inroom sink.n.01_1 bathroom)
         (ontop agent.n.01_1 floor.n.01_1)
     )
     
     (:goal 
-        (and 
-            (ontop ?pool.n.01_1 ?floor.n.01_1) 
-            (not 
+        (and
+            (not
                 (covered ?pool.n.01_1 ?stain.n.01_1)
             ) 
-            (ontop ?scrub_brush.n.01_1 ?shelf.n.01_1) 
         )
     )
 )

--- a/bddl/activity_definitions/decorating_for_religious_ceremony/problem0.bddl
+++ b/bddl/activity_definitions/decorating_for_religious_ceremony/problem0.bddl
@@ -8,7 +8,6 @@
         sign.n.02_1 - sign.n.02
         floor.n.01_1 - floor.n.01
         candlestick.n.01_1 - candlestick.n.01
-        straight_chair.n.01_1 - straight_chair.n.01
         wall.n.01_1 - wall.n.01
         shelf.n.01_1 - shelf.n.01
         agent.n.01_1 - agent.n.01
@@ -28,11 +27,10 @@
         (not 
             (attached wreath.n.01_1 wall.n.01_1)
         )
-        (inroom floor.n.01_1 playroom) 
-        (inroom straight_chair.n.01_1 playroom)
-        (inroom wall.n.01_1 playroom) 
-        (inroom cabinet.n.01_1 playroom) 
-        (inroom shelf.n.01_1 playroom) 
+        (inroom floor.n.01_1 living_room)
+        (inroom wall.n.01_1 living_room)
+        (inroom cabinet.n.01_1 living_room)
+        (inroom shelf.n.01_1 living_room)
         (ontop agent.n.01_1 floor.n.01_1)
     )
     

--- a/bddl/activity_definitions/distributing_event_T_shirts/problem0.bddl
+++ b/bddl/activity_definitions/distributing_event_T_shirts/problem0.bddl
@@ -19,8 +19,8 @@
         (inside jersey.n.03_6 carton.n.02_1) 
         (inside jersey.n.03_7 carton.n.02_1) 
         (inside jersey.n.03_8 carton.n.02_1) 
-        (inroom floor.n.01_1 corridor) 
-        (inroom booth.n.01_1 corridor) 
+        (inroom floor.n.01_1 empty_room)
+        (ontop booth.n.01_1 floor.n.01_1)
         (ontop agent.n.01_1 floor.n.01_1)
     )
     

--- a/bddl/activity_definitions/hang_a_dartboard/problem0.bddl
+++ b/bddl/activity_definitions/hang_a_dartboard/problem0.bddl
@@ -2,7 +2,7 @@
     (:domain omnigibson)
 
     (:objects
-        coffee_table.n.01_1 - coffee_table.n.01
+        table.n.02_1 - table.n.02
         dartboard.n.01_1 - dartboard.n.01
         wall.n.01_1 - wall.n.01
         dart.n.01_1 dart.n.01_2 dart.n.01_3 - dart.n.01
@@ -10,19 +10,19 @@
         floor.n.01_1 - floor.n.01
         agent.n.01_1 - agent.n.01
     )
-    
-    (:init 
-        (ontop dartboard.n.01_1 coffee_table.n.01_1) 
-        (ontop dart.n.01_1 dartboard.n.01_1) 
-        (ontop dart.n.01_3 dartboard.n.01_1) 
-        (ontop dart.n.01_2 dartboard.n.01_1) 
-        (not 
+
+    (:init
+        (ontop dartboard.n.01_1 table.n.02_1)
+        (ontop dart.n.01_1 dartboard.n.01_1)
+        (ontop dart.n.01_3 dartboard.n.01_1)
+        (ontop dart.n.01_2 dartboard.n.01_1)
+        (not
             (attached dartboard.n.01_1 wall.n.01_1)
         )
-        (ontop packing_box.n.02_1 coffee_table.n.01_1)
-        (inroom floor.n.01_1 living_room) 
-        (inroom wall.n.01_1 living_room) 
-        (inroom coffee_table.n.01_1 living_room) 
+        (ontop packing_box.n.02_1 table.n.02_1)
+        (inroom floor.n.01_1 living_room)
+        (inroom wall.n.01_1 living_room)
+        (inroom table.n.02_1 living_room)
         (ontop agent.n.01_1 floor.n.01_1)
     )
     

--- a/bddl/activity_definitions/hang_a_rug_on_a_wall/problem0.bddl
+++ b/bddl/activity_definitions/hang_a_rug_on_a_wall/problem0.bddl
@@ -5,7 +5,6 @@
         rug.n.01_1 - rug.n.01
         floor.n.01_1 - floor.n.01
         wall.n.01_1 - wall.n.01
-        coffee_table.n.01_1 - coffee_table.n.01
         agent.n.01_1 - agent.n.01
     )
     
@@ -16,7 +15,6 @@
         )
         (inroom wall.n.01_1 living_room) 
         (inroom floor.n.01_1 living_room) 
-        (inroom coffee_table.n.01_1 living_room) 
         (ontop agent.n.01_1 floor.n.01_1)
     )
     

--- a/bddl/activity_definitions/hang_paper_lanterns/problem0.bddl
+++ b/bddl/activity_definitions/hang_paper_lanterns/problem0.bddl
@@ -2,7 +2,7 @@
     (:domain omnigibson)
 
     (:objects
-        pedestal_table.n.01_1 - pedestal_table.n.01
+        table.n.02_1 - table.n.02
         lantern.n.01_1 lantern.n.01_2 - lantern.n.01
         floor.n.01_1 - floor.n.01
         wall.n.01_1 - wall.n.01
@@ -10,8 +10,8 @@
     )
     
     (:init 
-        (ontop lantern.n.01_1 pedestal_table.n.01_1) 
-        (ontop lantern.n.01_2 pedestal_table.n.01_1) 
+        (ontop lantern.n.01_1 table.n.02_1) 
+        (ontop lantern.n.01_2 table.n.02_1) 
         (not 
             (attached lantern.n.01_1 wall.n.01_1)
         )
@@ -20,7 +20,7 @@
         )
         (inroom floor.n.01_1 garden) 
         (inroom wall.n.01_1 garden) 
-        (inroom pedestal_table.n.01_1 garden) 
+        (inroom table.n.02_1 garden) 
         (ontop agent.n.01_1 floor.n.01_1)
     )
     

--- a/bddl/activity_definitions/hanging_address_numbers/problem0.bddl
+++ b/bddl/activity_definitions/hanging_address_numbers/problem0.bddl
@@ -3,16 +3,16 @@
 
     (:objects
         address.n.05_1 address.n.05_2 address.n.05_3 - address.n.05
-        pedestal_table.n.01_1 - pedestal_table.n.01
+        table.n.02_1 - table.n.02
         floor.n.01_1 - floor.n.01
         wall.n.01_1 - wall.n.01
         agent.n.01_1 - agent.n.01
     )
     
     (:init 
-        (ontop address.n.05_1 pedestal_table.n.01_1)
-        (ontop address.n.05_2 pedestal_table.n.01_1)
-        (ontop address.n.05_3 pedestal_table.n.01_1)
+        (ontop address.n.05_1 table.n.02_1)
+        (ontop address.n.05_2 table.n.02_1)
+        (ontop address.n.05_3 table.n.02_1)
         (not 
             (attached address.n.05_1 wall.n.01_1)
         )
@@ -22,9 +22,9 @@
         (not 
             (attached address.n.05_3 wall.n.01_1)
         )
-        (inroom floor.n.01_1 entryway) 
-        (inroom wall.n.01_1 entryway) 
-        (inroom pedestal_table.n.01_1 entryway)
+        (inroom floor.n.01_1 living_room)
+        (inroom wall.n.01_1 garden)
+        (inroom table.n.02_1 living_room)
         (ontop agent.n.01_1 floor.n.01_1)
     )
     

--- a/bddl/activity_definitions/hanging_blinds/problem0.bddl
+++ b/bddl/activity_definitions/hanging_blinds/problem0.bddl
@@ -3,7 +3,7 @@
 
     (:objects
         window_blind.n.01_1 - window_blind.n.01
-        coffee_table.n.01_1 - coffee_table.n.01
+        table.n.02_1 - table.n.02
         curtain_rod.n.01_1 - curtain_rod.n.01
         wall.n.01_1 - wall.n.01
         floor.n.01_1 - floor.n.01
@@ -11,11 +11,11 @@
     )
     
     (:init 
-        (ontop window_blind.n.01_1 coffee_table.n.01_1) 
+        (ontop window_blind.n.01_1 table.n.02_1) 
         (attached curtain_rod.n.01_1 wall.n.01_1) 
-        (inroom wall.n.01_1 living_room) 
-        (inroom floor.n.01_1 living_room) 
-        (inroom coffee_table.n.01_1 living_room) 
+        (inroom wall.n.01_1 living_room)
+        (inroom floor.n.01_1 living_room)
+        (inroom table.n.02_1 living_room) 
         (ontop agent.n.01_1 floor.n.01_1)
     )
     

--- a/bddl/activity_definitions/installing_smoke_detectors/problem0.bddl
+++ b/bddl/activity_definitions/installing_smoke_detectors/problem0.bddl
@@ -17,9 +17,9 @@
         (not
             (attached fire_alarm.n.02_2 wall.n.01_2)
         )
-        (inroom wall.n.01_1 bathroom) 
-        (inroom wall.n.01_2 living_room) 
-        (inroom floor.n.01_1 living_room) 
+        (inroom wall.n.01_1 kitchen)
+        (inroom wall.n.01_2 garage)
+        (inroom floor.n.01_1 kitchen)
         (ontop agent.n.01_1 floor.n.01_1)
     )
     

--- a/bddl/activity_definitions/laying_restaurant_table_for_dinner/problem0.bddl
+++ b/bddl/activity_definitions/laying_restaurant_table_for_dinner/problem0.bddl
@@ -10,8 +10,8 @@
         tablespoon.n.02_1 tablespoon.n.02_2 tablespoon.n.02_3 tablespoon.n.02_4 - tablespoon.n.02
         wineglass.n.01_1 wineglass.n.01_2 wineglass.n.01_3 wineglass.n.01_4 - wineglass.n.01
         water_glass.n.02_1 water_glass.n.02_2 water_glass.n.02_3 water_glass.n.02_4 - water_glass.n.02
-        armchair.n.01_1 armchair.n.01_2 armchair.n.01_3 armchair.n.01_4 - armchair.n.01
-        breakfast_table.n.01_1 breakfast_table.n.01_2 - breakfast_table.n.01
+        chair.n.01_1 chair.n.01_2 chair.n.01_3 chair.n.01_4 - chair.n.01
+        table.n.02_1 table.n.02_2 - table.n.02
         floor.n.01_1 - floor.n.01
         agent.n.01_1 - agent.n.01
     )
@@ -21,14 +21,14 @@
         (ontop plate.n.04_2 plate.n.04_1) 
         (ontop plate.n.04_3 plate.n.04_2) 
         (ontop plate.n.04_4 plate.n.04_3) 
-        (ontop wineglass.n.01_1 breakfast_table.n.01_2) 
-        (ontop wineglass.n.01_2 breakfast_table.n.01_2) 
-        (ontop wineglass.n.01_3 breakfast_table.n.01_2) 
-        (ontop wineglass.n.01_4 breakfast_table.n.01_2) 
-        (ontop water_glass.n.02_1 breakfast_table.n.01_2)
-        (ontop water_glass.n.02_2 breakfast_table.n.01_2)
-        (ontop water_glass.n.02_3 breakfast_table.n.01_2)
-        (ontop water_glass.n.02_4 breakfast_table.n.01_2)
+        (ontop wineglass.n.01_1 table.n.02_2) 
+        (ontop wineglass.n.01_2 table.n.02_2) 
+        (ontop wineglass.n.01_3 table.n.02_2) 
+        (ontop wineglass.n.01_4 table.n.02_2) 
+        (ontop water_glass.n.02_1 table.n.02_2)
+        (ontop water_glass.n.02_2 table.n.02_2)
+        (ontop water_glass.n.02_3 table.n.02_2)
+        (ontop water_glass.n.02_4 table.n.02_2)
         (inside tablefork.n.01_1 cabinet.n.01_1) 
         (inside tablefork.n.01_2 cabinet.n.01_1) 
         (inside tablefork.n.01_3 cabinet.n.01_1) 
@@ -41,18 +41,18 @@
         (inside tablespoon.n.02_2 cabinet.n.01_1)
         (inside tablespoon.n.02_3 cabinet.n.01_1)
         (inside tablespoon.n.02_4 cabinet.n.01_1)
-        (ontop dinner_napkin.n.01_1 breakfast_table.n.01_2)
-        (ontop dinner_napkin.n.01_2 breakfast_table.n.01_2)
-        (ontop dinner_napkin.n.01_3 breakfast_table.n.01_2)
-        (ontop dinner_napkin.n.01_4 breakfast_table.n.01_2)
-        (inroom breakfast_table.n.01_1 dining_room) 
+        (ontop dinner_napkin.n.01_1 table.n.02_2)
+        (ontop dinner_napkin.n.01_2 table.n.02_2)
+        (ontop dinner_napkin.n.01_3 table.n.02_2)
+        (ontop dinner_napkin.n.01_4 table.n.02_2)
+        (inroom table.n.02_1 dining_room) 
         (inroom cabinet.n.01_1 kitchen) 
         (inroom floor.n.01_1 kitchen) 
-        (inroom armchair.n.01_1 dining_room)
-        (inroom armchair.n.01_2 dining_room)
-        (inroom armchair.n.01_3 dining_room)
-        (inroom armchair.n.01_4 dining_room)
-        (inroom breakfast_table.n.01_2 kitchen)
+        (inroom chair.n.01_1 dining_room)
+        (inroom chair.n.01_2 dining_room)
+        (inroom chair.n.01_3 dining_room)
+        (inroom chair.n.01_4 dining_room)
+        (inroom table.n.02_2 kitchen)
         (ontop agent.n.01_1 floor.n.01_1)
     )
     
@@ -60,7 +60,7 @@
         (and 
             (forall 
                 (?plate.n.04 - plate.n.04)
-                (ontop ?plate.n.04 ?breakfast_table.n.01_1)
+                (ontop ?plate.n.04 ?table.n.02_1)
             )
             (forall 
                 (?dinner_napkin.n.01 - dinner_napkin.n.01)
@@ -68,8 +68,8 @@
             )
             (forpairs
                 (?plate.n.04 - plate.n.04)
-                (?armchair.n.01 - armchair.n.01)
-                (nextto ?plate.n.04 ?armchair.n.01)
+                (?chair.n.01 - chair.n.01)
+                (nextto ?plate.n.04 ?chair.n.01)
             )
             (forpairs
                 (?wineglass.n.01 - wineglass.n.01)

--- a/bddl/activity_definitions/make_a_bake_sale_stand_stall/problem0.bddl
+++ b/bddl/activity_definitions/make_a_bake_sale_stand_stall/problem0.bddl
@@ -40,8 +40,8 @@
         (inside tupperware.n.01_2 carton.n.02_2)
         (ontop carton.n.02_1 floor.n.01_1) 
         (ontop carton.n.02_2 floor.n.01_1) 
-        (inroom booth.n.01_1 corridor)
-        (inroom floor.n.01_1 corridor)
+        (ontop booth.n.01_1 floor.n.01_1)
+        (inroom floor.n.01_1 empty_room)
         (ontop agent.n.01_1 floor.n.01_1)
     )
     

--- a/bddl/activity_definitions/picking_up_baggage/problem0.bddl
+++ b/bddl/activity_definitions/picking_up_baggage/problem0.bddl
@@ -3,7 +3,7 @@
 
     (:objects
         backpack.n.01_1 - backpack.n.01
-        desk.n.01_1 - desk.n.01
+        table.n.02_1 - table.n.02
         bag.n.06_1 - bag.n.06
         car.n.01_1 - car.n.01
         floor.n.01_1 floor.n.01_2 - floor.n.01
@@ -12,10 +12,10 @@
     
     (:init
         (ontop car.n.01_1 floor.n.01_2) 
-        (ontop backpack.n.01_1 desk.n.01_1) 
+        (ontop backpack.n.01_1 table.n.02_1) 
         (ontop bag.n.06_1 floor.n.01_1) 
         (inroom floor.n.01_1 bedroom) 
-        (inroom desk.n.01_1 bedroom) 
+        (inroom table.n.02_1 bedroom) 
         (inroom floor.n.01_2 garage)
         (ontop agent.n.01_1 floor.n.01_1)
     )

--- a/bddl/activity_definitions/putting_away_purchased_clothes/problem0.bddl
+++ b/bddl/activity_definitions/putting_away_purchased_clothes/problem0.bddl
@@ -5,7 +5,7 @@
         jean.n.01_1 jean.n.01_2 - jean.n.01
         floor.n.01_1 - floor.n.01
         jersey.n.03_1 jersey.n.03_2 - jersey.n.03
-        desk.n.01_1 - desk.n.01
+        table.n.02_1 - table.n.02
         sweater.n.01_1 sweater.n.01_2 - sweater.n.01
         hanger.n.02_1 hanger.n.02_2 hanger.n.02_3 hanger.n.02_4 hanger.n.02_5 hanger.n.02_6 - hanger.n.02
         wardrobe.n.01_1 - wardrobe.n.01
@@ -15,10 +15,10 @@
     (:init 
         (ontop jean.n.01_1 floor.n.01_1) 
         (ontop jean.n.01_2 floor.n.01_1) 
-        (ontop jersey.n.03_1 desk.n.01_1) 
-        (ontop jersey.n.03_2 desk.n.01_1) 
-        (ontop sweater.n.01_1 desk.n.01_1) 
-        (ontop sweater.n.01_2 desk.n.01_1) 
+        (ontop jersey.n.03_1 table.n.02_1) 
+        (ontop jersey.n.03_2 table.n.02_1) 
+        (ontop sweater.n.01_1 table.n.02_1) 
+        (ontop sweater.n.01_2 table.n.02_1) 
         (attached hanger.n.02_1 wardrobe.n.01_1)
         (attached hanger.n.02_2 wardrobe.n.01_1)
         (attached hanger.n.02_3 wardrobe.n.01_1)
@@ -26,7 +26,7 @@
         (attached hanger.n.02_5 wardrobe.n.01_1)
         (attached hanger.n.02_6 wardrobe.n.01_1)
         (inroom floor.n.01_1 closet) 
-        (inroom desk.n.01_1 bedroom) 
+        (inroom table.n.02_1 bedroom) 
         (inroom wardrobe.n.01_1 closet) 
         (ontop agent.n.01_1 floor.n.01_1)
     )

--- a/bddl/activity_definitions/putting_backpack_in_car_for_school/problem0.bddl
+++ b/bddl/activity_definitions/putting_backpack_in_car_for_school/problem0.bddl
@@ -5,7 +5,7 @@
         car.n.01_1 - car.n.01
         floor.n.01_1 floor.n.01_2 - floor.n.01
         backpack.n.01_1 - backpack.n.01
-        desk.n.01_1 - desk.n.01
+        table.n.02_1 - table.n.02
         book.n.02_1 - book.n.02
         pencil_box.n.01_1 - pencil_box.n.01
         agent.n.01_1 - agent.n.01
@@ -13,11 +13,11 @@
     
     (:init 
         (ontop car.n.01_1 floor.n.01_1) 
-        (ontop backpack.n.01_1 desk.n.01_1) 
+        (ontop backpack.n.01_1 table.n.02_1) 
         (inside book.n.02_1 backpack.n.01_1) 
         (inside pencil_box.n.01_1 backpack.n.01_1) 
         (inroom floor.n.01_1 garden) 
-        (inroom desk.n.01_1 bedroom)
+        (inroom table.n.02_1 bedroom)
         (inroom floor.n.01_2 bedroom) 
         (ontop agent.n.01_1 floor.n.01_2)
     )

--- a/bddl/activity_definitions/putting_laundry_in_drawer/problem0.bddl
+++ b/bddl/activity_definitions/putting_laundry_in_drawer/problem0.bddl
@@ -10,7 +10,7 @@
         pajama.n.02_1 - pajama.n.02
         tank_top.n.01_1 tank_top.n.01_2 - tank_top.n.01
         sweatshirt.n.01_1 - sweatshirt.n.01
-        chest_of_drawers.n.01_1 - chest_of_drawers.n.01
+        cabinet.n.01_1 - cabinet.n.01
         agent.n.01_1 - agent.n.01
     )
     
@@ -25,38 +25,38 @@
         (ontop tank_top.n.01_2 desk.n.01_1) 
         (inroom desk.n.01_1 bedroom)
         (inroom floor.n.01_1 bedroom)
-        (inroom chest_of_drawers.n.01_1 bedroom)
+        (inroom cabinet.n.01_1 bedroom)
         (ontop agent.n.01_1 floor.n.01_1)
     )
     
     (:goal 
         (and 
             (exists
-                (?chest_of_drawers.n.01 - chest_of_drawers.n.01)
-                (inside ?short_pants.n.01_1 ?chest_of_drawers.n.01)
+                (?cabinet.n.01 - cabinet.n.01)
+                (inside ?short_pants.n.01_1 ?cabinet.n.01)
             )
             (folded ?short_pants.n.01_1)
             (exists
-                (?chest_of_drawers.n.01 - chest_of_drawers.n.01)
-                (inside ?jean.n.01_1 ?chest_of_drawers.n.01)
+                (?cabinet.n.01 - cabinet.n.01)
+                (inside ?jean.n.01_1 ?cabinet.n.01)
             )
             (folded ?jean.n.01_1)
             (exists
-                (?chest_of_drawers.n.01 - chest_of_drawers.n.01)
-                (inside ?pajama.n.02_1 ?chest_of_drawers.n.01)
+                (?cabinet.n.01 - cabinet.n.01)
+                (inside ?pajama.n.02_1 ?cabinet.n.01)
             )
             (folded ?pajama.n.02_1)
             (exists
-                (?chest_of_drawers.n.01 - chest_of_drawers.n.01)
-                (inside ?sweatshirt.n.01_1 ?chest_of_drawers.n.01)
+                (?cabinet.n.01 - cabinet.n.01)
+                (inside ?sweatshirt.n.01_1 ?cabinet.n.01)
             )
             (folded ?sweatshirt.n.01_1)
             (forall 
                 (?polo_shirt.n.01 - polo_shirt.n.01) 
                 (and
                     (exists 
-                        (?chest_of_drawers.n.01 - chest_of_drawers.n.01)
-                        (inside ?polo_shirt.n.01 ?chest_of_drawers.n.01)   
+                        (?cabinet.n.01 - cabinet.n.01)
+                        (inside ?polo_shirt.n.01 ?cabinet.n.01)   
                     )
                     (folded ?polo_shirt.n.01)             
                 )
@@ -65,8 +65,8 @@
                 (?tank_top.n.01 - tank_top.n.01) 
                 (and
                     (exists 
-                        (?chest_of_drawers.n.01 - chest_of_drawers.n.01)
-                        (inside ?tank_top.n.01 ?chest_of_drawers.n.01)   
+                        (?cabinet.n.01 - cabinet.n.01)
+                        (inside ?tank_top.n.01 ?cabinet.n.01)   
                     )
                     (folded ?tank_top.n.01)             
                 )

--- a/bddl/activity_definitions/putting_meal_in_fridge_at_work/problem0.bddl
+++ b/bddl/activity_definitions/putting_meal_in_fridge_at_work/problem0.bddl
@@ -5,7 +5,7 @@
         electric_refrigerator.n.01_1 - electric_refrigerator.n.01
         club_sandwich.n.01_1 club_sandwich.n.01_2 - club_sandwich.n.01
         plate.n.04_1 - plate.n.04
-        desk.n.01_1 - desk.n.01
+        table.n.02_1 - table.n.02
         floor.n.01_1 - floor.n.01
         agent.n.01_1 - agent.n.01
     )
@@ -13,10 +13,10 @@
     (:init
         (ontop club_sandwich.n.01_1 plate.n.04_1) 
         (ontop club_sandwich.n.01_2 plate.n.04_1) 
-        (ontop plate.n.04_1 desk.n.01_1)
+        (ontop plate.n.04_1 table.n.02_1)
         (inroom floor.n.01_1 private_office) 
-        (inroom desk.n.01_1 private_office) 
-        (inroom electric_refrigerator.n.01_1 private_office) 
+        (inroom table.n.02_1 private_office) 
+        (inroom electric_refrigerator.n.01_1 break_room)
         (ontop agent.n.01_1 floor.n.01_1)
     )
     

--- a/bddl/activity_definitions/recycling_newspapers/problem0.bddl
+++ b/bddl/activity_definitions/recycling_newspapers/problem0.bddl
@@ -5,7 +5,7 @@
         recycling_bin.n.01_1 - recycling_bin.n.01
         floor.n.01_1 - floor.n.01
         newspaper.n.03_1 newspaper.n.03_2 newspaper.n.03_3 - newspaper.n.03
-        swivel_chair.n.01_1 - swivel_chair.n.01
+        chair.n.01_1 - chair.n.01
         agent.n.01_1 - agent.n.01
     )
     
@@ -13,10 +13,9 @@
         (ontop recycling_bin.n.01_1 floor.n.01_1) 
         (inside newspaper.n.03_1 recycling_bin.n.01_1) 
         (inside newspaper.n.03_2 recycling_bin.n.01_1) 
-        (ontop newspaper.n.03_3 swivel_chair.n.01_1)
+        (ontop newspaper.n.03_3 chair.n.01_1)
         (inroom floor.n.01_1 private_office) 
-        (inroom recycling_bin.n.01_1 private_office) 
-        (inroom swivel_chair.n.01_1 private_office)
+        (inroom chair.n.01_1 private_office)
         (ontop agent.n.01_1 floor.n.01_1)
     )
     

--- a/bddl/activity_definitions/remove_a_wall_mirror/problem0.bddl
+++ b/bddl/activity_definitions/remove_a_wall_mirror/problem0.bddl
@@ -2,7 +2,6 @@
     (:domain omnigibson)
 
     (:objects
-        cabinet.n.01_1 - cabinet.n.01
         mirror.n.01_1 - mirror.n.01
         wall.n.01_1 - wall.n.01
         floor.n.01_1 - floor.n.01
@@ -11,12 +10,10 @@
     
     (:init 
         (attached mirror.n.01_1 wall.n.01_1) 
-        (inroom floor.n.01_1 bedroom) 
-        (inroom cabinet.n.01_1 bedroom) 
-        (inroom wall.n.01_1 bedroom) 
-        (inroom mirror.n.01_1 bedroom) 
+        (inroom floor.n.01_1 bathroom)
+        (inroom wall.n.01_1 bathroom)
+        (inroom mirror.n.01_1 bathroom)
         (ontop agent.n.01_1 floor.n.01_1)
-    
     )
     
     (:goal 

--- a/bddl/activity_definitions/repairs_to_furniture/problem0.bddl
+++ b/bddl/activity_definitions/repairs_to_furniture/problem0.bddl
@@ -2,7 +2,7 @@
     (:domain omnigibson)
 
     (:objects
-        desk.n.01_1 - desk.n.01
+        table.n.02_1 - table.n.02
         incision.n.01_1 - incision.n.01
         emery_paper.n.01_1 - emery_paper.n.01
         floor.n.01_1 - floor.n.01
@@ -10,17 +10,17 @@
     )
     
     (:init 
-        (covered desk.n.01_1 incision.n.01_1) 
-        (ontop emery_paper.n.01_1 desk.n.01_1)
+        (covered table.n.02_1 incision.n.01_1) 
+        (ontop emery_paper.n.01_1 table.n.02_1)
         (inroom floor.n.01_1 garage) 
-        (inroom desk.n.01_1 garage) 
+        (ontop table.n.02_1 floor.n.01_1)
         (ontop agent.n.01_1 floor.n.01_1)
     )
     
     (:goal 
         (and 
             (not 
-                (covered ?desk.n.01_1 ?incision.n.01_1)
+                (covered ?table.n.02_1 ?incision.n.01_1)
             )
         )
     )

--- a/bddl/activity_definitions/selling_products_at_flea_market/problem0.bddl
+++ b/bddl/activity_definitions/selling_products_at_flea_market/problem0.bddl
@@ -31,7 +31,7 @@
         (inside price_tag.n.01_3 carton.n.02_2) 
         (inside price_tag.n.01_4 carton.n.02_2) 
         (inroom floor.n.01_1 empty_room)
-        (inroom booth.n.01_1 empty_room)
+        (ontop booth.n.01_1 floor.n.01_1)
         (ontop agent.n.01_1 floor.n.01_1)
     )
     

--- a/bddl/activity_definitions/set_up_a_home_office_in_your_garage/problem0.bddl
+++ b/bddl/activity_definitions/set_up_a_home_office_in_your_garage/problem0.bddl
@@ -7,8 +7,7 @@
         computer.n.01_1 - computer.n.01
         router.n.02_1 - router.n.02
         carton.n.02_1 - carton.n.02
-        swivel_chair.n.01_1 - swivel_chair.n.01
-        desk.n.01_1 - desk.n.01
+        table.n.02_1 - table.n.02
         agent.n.01_1 - agent.n.01
     )
     
@@ -17,16 +16,15 @@
         (inside computer.n.01_1 carton.n.02_1) 
         (inside router.n.02_1 carton.n.02_1) 
         (ontop carton.n.02_1 floor.n.01_1)
-        (inroom floor.n.01_1 corridor) 
-        (inroom swivel_chair.n.01_1 garage)
-        (inroom desk.n.01_1 garage) 
+        (inroom floor.n.01_1 garage)
+        (ontop table.n.02_1 floor.n.01_1)
         (ontop agent.n.01_1 floor.n.01_1)
     )
     
     (:goal 
         (and 
-            (ontop ?table_lamp.n.01_1 ?desk.n.01_1) 
-            (ontop ?computer.n.01_1 ?desk.n.01_1) 
+            (ontop ?table_lamp.n.01_1 ?table.n.02_1) 
+            (ontop ?computer.n.01_1 ?table.n.02_1) 
             (ontop ?router.n.02_1 ?floor.n.01_1)
         )
     )

--- a/bddl/activity_definitions/set_up_a_preschool_classroom/problem0.bddl
+++ b/bddl/activity_definitions/set_up_a_preschool_classroom/problem0.bddl
@@ -14,11 +14,10 @@
         packing_box.n.02_1 packing_box.n.02_2 - packing_box.n.02
         mat.n.03_1 - mat.n.03
         blackboard.n.01_1 - blackboard.n.01
-        desk.n.01_1 desk.n.01_10 desk.n.01_2 desk.n.01_3 desk.n.01_4 desk.n.01_5 desk.n.01_6 desk.n.01_7 desk.n.01_8 desk.n.01_9 - desk.n.01
+        table.n.02_1 table.n.02_10 table.n.02_2 table.n.02_3 table.n.02_4 table.n.02_5 table.n.02_6 table.n.02_7 table.n.02_8 table.n.02_9 - table.n.02
         wall_clock.n.01_1 - wall_clock.n.01
-        wall.n.01_1 - wall.n.01
         map.n.01_1 - map.n.01
-        straight_chair.n.01_1 straight_chair.n.01_10 straight_chair.n.01_2 straight_chair.n.01_3 straight_chair.n.01_4 straight_chair.n.01_5 straight_chair.n.01_6 straight_chair.n.01_7 straight_chair.n.01_8 straight_chair.n.01_9 - straight_chair.n.01
+        chair.n.01_1 chair.n.01_10 chair.n.01_2 chair.n.01_3 chair.n.01_4 chair.n.01_5 chair.n.01_6 chair.n.01_7 chair.n.01_8 chair.n.01_9 - chair.n.01
         agent.n.01_1 - agent.n.01
     )
     
@@ -48,30 +47,29 @@
         (ontop backpack.n.01_4 floor.n.01_1) 
         (ontop mat.n.03_1 floor.n.01_1) 
         (inroom blackboard.n.01_1 classroom) 
-        (inroom desk.n.01_1 classroom) 
-        (inroom desk.n.01_2 classroom) 
-        (inroom desk.n.01_3 classroom) 
-        (inroom desk.n.01_4 classroom) 
-        (inroom desk.n.01_5 classroom) 
-        (inroom desk.n.01_6 classroom) 
-        (inroom desk.n.01_7 classroom) 
-        (inroom desk.n.01_8 classroom) 
-        (inroom desk.n.01_9 classroom) 
-        (inroom desk.n.01_10 classroom) 
+        (inroom table.n.02_1 classroom) 
+        (inroom table.n.02_2 classroom) 
+        (inroom table.n.02_3 classroom) 
+        (inroom table.n.02_4 classroom) 
+        (inroom table.n.02_5 classroom) 
+        (inroom table.n.02_6 classroom) 
+        (inroom table.n.02_7 classroom) 
+        (inroom table.n.02_8 classroom) 
+        (inroom table.n.02_9 classroom) 
+        (inroom table.n.02_10 classroom) 
         (inroom wall_clock.n.01_1 classroom) 
         (inroom map.n.01_1 classroom) 
-        (inroom straight_chair.n.01_1 classroom)
-        (inroom straight_chair.n.01_2 classroom)
-        (inroom straight_chair.n.01_3 classroom)
-        (inroom straight_chair.n.01_4 classroom)
-        (inroom straight_chair.n.01_5 classroom)
-        (inroom straight_chair.n.01_6 classroom)
-        (inroom straight_chair.n.01_7 classroom)
-        (inroom straight_chair.n.01_8 classroom)
-        (inroom straight_chair.n.01_9 classroom)
-        (inroom straight_chair.n.01_10 classroom)
+        (inroom chair.n.01_1 classroom)
+        (inroom chair.n.01_2 classroom)
+        (inroom chair.n.01_3 classroom)
+        (inroom chair.n.01_4 classroom)
+        (inroom chair.n.01_5 classroom)
+        (inroom chair.n.01_6 classroom)
+        (inroom chair.n.01_7 classroom)
+        (inroom chair.n.01_8 classroom)
+        (inroom chair.n.01_9 classroom)
+        (inroom chair.n.01_10 classroom)
         (inroom floor.n.01_1 classroom) 
-        (inroom wall.n.01_1 classroom)
         (ontop agent.n.01_1 floor.n.01_1)
     )
     
@@ -79,30 +77,29 @@
         (and 
             (forpairs 
                 (?notebook.n.01 - notebook.n.01) 
-                (?desk.n.01 - desk.n.01)
-                (ontop ?notebook.n.01 ?desk.n.01)
+                (?table.n.02 - table.n.02)
+                (ontop ?notebook.n.01 ?table.n.02)
             ) 
             (touching ?blackboard_eraser.n.01_1 ?blackboard.n.01_1) 
             (forpairs 
                 (?pencil.n.01 - pencil.n.01) 
-                (?desk.n.01 - desk.n.01)
-                (ontop ?pencil.n.01 ?desk.n.01)
+                (?table.n.02 - table.n.02)
+                (ontop ?pencil.n.01 ?table.n.02)
             ) 
             (forpairs 
                 (?pen.n.01 - pen.n.01) 
-                (?desk.n.01 - desk.n.01)
-                (ontop ?pen.n.01 ?desk.n.01_4)
+                (?table.n.02 - table.n.02)
+                (ontop ?pen.n.01 ?table.n.02_4)
             ) 
             (exists 
-                (?desk.n.01 - desk.n.01)
-                (ontop ?globe.n.03_1 ?desk.n.01) 
+                (?table.n.02 - table.n.02)
+                (ontop ?globe.n.03_1 ?table.n.02) 
             )
             (forall 
                 (?backpack.n.01 - backpack.n.01) 
                 (and
                     (ontop ?backpack.n.01 ?floor.n.01_1)
-                    (touching ?wall.n.01_1 ?backpack.n.01)
-                    (or 
+                    (or
                         (nextto ?backpack.n.01 ?backpack.n.01_1)
                         (nextto ?backpack.n.01 ?backpack.n.01_2)
                         (nextto ?backpack.n.01 ?backpack.n.01_3)
@@ -111,8 +108,8 @@
                 )
             ) 
             (exists 
-                (?desk.n.01 - desk.n.01)
-                (ontop ?computer.n.01_1 ?desk.n.01) 
+                (?table.n.02 - table.n.02)
+                (ontop ?computer.n.01_1 ?table.n.02) 
             )
             (forall 
                 (?teddy.n.01 - teddy.n.01) 

--- a/bddl/activity_definitions/setup_a_baby_crib/problem0.bddl
+++ b/bddl/activity_definitions/setup_a_baby_crib/problem0.bddl
@@ -17,7 +17,7 @@
         (inside blanket.n.01_1 shelf.n.01_1)
         (inroom floor.n.01_1 childs_room) 
         (inroom shelf.n.01_1 childs_room) 
-        (inroom crib.n.01_1 childs_room) 
+        (ontop crib.n.01_1 floor.n.01_1)
         (ontop agent.n.01_1 floor.n.01_1)
     )
     

--- a/bddl/activity_definitions/stash_snacks_in_your_room/problem0.bddl
+++ b/bddl/activity_definitions/stash_snacks_in_your_room/problem0.bddl
@@ -10,9 +10,8 @@
     	granola_bar.n.01_1 granola_bar.n.01_2 - granola_bar.n.01
         sack.n.01_1 - sack.n.01
     	chocolate_biscuit.n.01_1 chocolate_biscuit.n.01_2 - chocolate_biscuit.n.01
-    	desk.n.01_1 - desk.n.01
+    	table.n.02_1 - table.n.02
     	cabinet.n.01_1 - cabinet.n.01
-    	chest_of_drawers.n.01_1 - chest_of_drawers.n.01
     	floor.n.01_1 - floor.n.01
     	agent.n.01_1 - agent.n.01
     )
@@ -29,11 +28,10 @@
         (ontop granola_bar.n.01_2 sack.n.01_1)
         (ontop chocolate_biscuit.n.01_1 sack.n.01_1)
         (ontop chocolate_biscuit.n.01_2 sack.n.01_1)
-        (ontop sack.n.01_1 desk.n.01_1)
+        (ontop sack.n.01_1 table.n.02_1)
         (inroom bed.n.01_1 bedroom) 
         (inroom cabinet.n.01_1 bedroom) 
-        (inroom chest_of_drawers.n.01_1 bedroom) 
-        (inroom desk.n.01_1 bedroom) 
+        (inroom table.n.02_1 bedroom)
         (inroom floor.n.01_1 bedroom) 
         (ontop agent.n.01_1 floor.n.01_1)
     )
@@ -54,11 +52,11 @@
             ) 
             (forall 
                 (?chocolate_bar.n.01 - chocolate_bar.n.01) 
-                (ontop ?chocolate_bar.n.01 ?desk.n.01_1)
+                (ontop ?chocolate_bar.n.01 ?table.n.02_1)
             ) 
             (forall 
                 (?granola_bar.n.01 - granola_bar.n.01) 
-                (ontop ?granola_bar.n.01 ?chest_of_drawers.n.01_1)
+                (ontop ?granola_bar.n.01 ?cabinet.n.01_1)
             ) 
             (forall 
                 (?chocolate_biscuit.n.01 - chocolate_biscuit.n.01) 

--- a/bddl/activity_definitions/stripping_furniture/problem0.bddl
+++ b/bddl/activity_definitions/stripping_furniture/problem0.bddl
@@ -5,7 +5,7 @@
         newspaper.n.03_1 - newspaper.n.03
         floor.n.01_1 - floor.n.01
         house_paint.n.01_1 - house_paint.n.01
-        desk.n.01_1 - desk.n.01
+        table.n.02_1 - table.n.02
         solvent.n.01_1 - solvent.n.01
         solvent__bottle.n.01_1 - solvent__bottle.n.01
         scraper.n.01_1 - scraper.n.01
@@ -16,21 +16,21 @@
     
     (:init 
         (ontop newspaper.n.03_1 floor.n.01_1) 
-        (covered desk.n.01_1 house_paint.n.01_1)
+        (covered table.n.02_1 house_paint.n.01_1)
         (filled solvent__bottle.n.01_1 solvent.n.01_1)
-        (ontop solvent__bottle.n.01_1 desk.n.01_1)
-        (ontop scraper.n.01_1 desk.n.01_1)
-        (ontop scrub_brush.n.01_1 desk.n.01_1)
+        (ontop solvent__bottle.n.01_1 table.n.02_1)
+        (ontop scraper.n.01_1 table.n.02_1)
+        (ontop scrub_brush.n.01_1 table.n.02_1)
         (ontop bucket.n.01_1 floor.n.01_1) 
         (inroom floor.n.01_1 garage) 
-        (inroom desk.n.01_1 garage)
+        (ontop table.n.02_1 floor.n.01_1)
         (ontop agent.n.01_1 floor.n.01_1)
     )
     
     (:goal 
         (and 
             (not 
-                (covered ?desk.n.01_1 ?house_paint.n.01_1)
+                (covered ?table.n.02_1 ?house_paint.n.01_1)
             )
         )
     )

--- a/bddl/activity_definitions/tidy_your_garden/problem0.bddl
+++ b/bddl/activity_definitions/tidy_your_garden/problem0.bddl
@@ -27,7 +27,7 @@
         (inroom lawn.n.01_1 garden) 
         (inroom floor.n.01_1 garden) 
         (inroom rail_fence.n.01_1 garden) 
-        (inroom bench.n.01_1 garden) 
+        (ontop bench.n.01_1 lawn.n.01_1)
         (ontop agent.n.01_1 floor.n.01_1)
     )
     

--- a/bddl/bddl_verification.py
+++ b/bddl/bddl_verification.py
@@ -113,7 +113,8 @@ ROOMS = set([
     "staircase",
     "spa",
     "television_room",
-    "lobby"
+    "lobby",
+    "break_room",
 ])
 PLACEMENTS = set([
     "ontop",


### PR DESCRIPTION
Only 3 tasks are not matched now.

- decorating_for_religious_ceremony-0
  - requires walls in living room, Beechwood_0_int does satisfy this, but the task also requires a cabinet and a shelf in the same room, and Beechwood_0_int doesn't satisfy. The cabinet and shelf are sort of needed in the task. So I will pass for now.
- make_a_clothes_line-0
  - requires walls in utility_room
- make_the_workplace_exciting-0
  - requires walls in meeting_room